### PR TITLE
Overridden function signature must match parent

### DIFF
--- a/src/Normalizer/EntityReferenceItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceItemNormalizer.php
@@ -119,7 +119,7 @@ class EntityReferenceItemNormalizer extends FieldItemNormalizer implements UuidR
   /**
    * {@inheritdoc}
    */
-  protected function constructValue($data, $context) {
+  protected function constructValue(array $data, array $context) {
     $field_item = $context['target_instance'];
     $field_definition = $field_item->getFieldDefinition();
     $target_type = $field_definition->getSetting('target_type');

--- a/src/Normalizer/FieldNormalizer.php
+++ b/src/Normalizer/FieldNormalizer.php
@@ -3,6 +3,7 @@
 namespace Drupal\jsonld\Normalizer;
 
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Field\FieldItemListInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**


### PR DESCRIPTION
Due to cleaning up function signatures, I saw this error when running a `drupal cache:rebuild all`

```
PHP Warning:  Declaration of Drupal\jsonld\Normalizer\EntityReferenceItemNormalizer::constructValue($data, $context) should be compatible with Drupal\jsonld\Normalizer\FieldItemNormalizer::constructValue(array $data, array $context) in /var/www/html/drupal/web/modules/contrib/claw-jsonld/src/Normalizer/EntityReferenceItemNormalizer.php on line 13
```

So fixing...