### PR TITLE
Fix issue with travis running force pushed commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_install:
 install:
   - git clone https://github.com/Islandora-CLAW/islandora.git $HOME/islandora
   - $SCRIPT_DIR/travis_setup.sh
+  - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR; composer config repositories.local path "$TRAVIS_BUILD_DIR"
-  - composer require "islandora/claw-jsonld:dev-$TRAVIS_COMMIT as dev-8.x-1.x" --prefer-source
+  - composer require "islandora/claw-jsonld:dev-travis-testing as dev-8.x-1.x" --prefer-source
   - cd web; drush en -y jsonld
 
 script:


### PR DESCRIPTION
TravisCi provides the $TRAVIS_COMMIT environment variable which I was
using to get composer to install the correct version. However it appears
that under some circumstances travis does not set this variable to the
correct commit hash, which can cause our builds to fail. This avoids
using that variable all together to avoid that problem.

Related to:
https://github.com/Islandora-CLAW/CLAW/issues/540
